### PR TITLE
Add blacklisted tag to the message of blacklisted results

### DIFF
--- a/src/commands/lewd/danbooru.js
+++ b/src/commands/lewd/danbooru.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -109,7 +113,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})`;
             }
           }
 

--- a/src/commands/lewd/derpibooru.js
+++ b/src/commands/lewd/derpibooru.js
@@ -32,6 +32,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -122,7 +126,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://derpibooru.org/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://derpibooru.org/${id})`;
             }
           }
 

--- a/src/commands/lewd/e621.js
+++ b/src/commands/lewd/e621.js
@@ -31,6 +31,20 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getMatches(arr1, arr2) {
+  var matchObj = {}, matched = [];
+  for (var i = 0, l = arr1.length; i < l; i++) {
+    matchObj[arr1[i]] = (matchObj[arr1[i]] || 0) + 1;
+  }
+  for (i = 0; i < arr2.length; i++) {
+    var val = arr2[i];
+    if (val in matchObj) {
+      matched.push(val);
+    }
+  }
+  return matched;
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -99,6 +113,7 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
+              let matchBlackList = getMatches(blacklist, tags);
               if (removeValue === 'true') {
                 blacklistHits++;
                 if (blacklistHits > 0 && currentPosition === count) {
@@ -108,7 +123,7 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://e621.net/post/show/${id})`;
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${matchBlackList.join()} | **Link:** [Click Here](https://e621.net/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/e621.js
+++ b/src/commands/lewd/e621.js
@@ -103,7 +103,6 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              let blackListMatch = getOne(blacklist, tags);
               if (removeValue === 'true') {
                 blacklistHits++;
                 if (blacklistHits > 0 && currentPosition === count) {
@@ -113,7 +112,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blackListMatch} | **Link:** [Click Here](https://e621.net/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://e621.net/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/e621.js
+++ b/src/commands/lewd/e621.js
@@ -31,18 +31,8 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
-function getMatches(arr1, arr2) {
-  var matchObj = {}, matched = [];
-  for (var i = 0, l = arr1.length; i < l; i++) {
-    matchObj[arr1[i]] = (matchObj[arr1[i]] || 0) + 1;
-  }
-  for (i = 0; i < arr2.length; i++) {
-    var val = arr2[i];
-    if (val in matchObj) {
-      matched.push(val);
-    }
-  }
-  return matched;
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
 }
 
 function tags(client, evt, suffix) {
@@ -113,7 +103,7 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              let matchBlackList = getMatches(blacklist, tags);
+              let blackListMatch = getOne(blacklist, tags);
               if (removeValue === 'true') {
                 blacklistHits++;
                 if (blacklistHits > 0 && currentPosition === count) {
@@ -123,7 +113,7 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${matchBlackList.join()} | **Link:** [Click Here](https://e621.net/post/show/${id})`;
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blackListMatch} | **Link:** [Click Here](https://e621.net/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/e926.js
+++ b/src/commands/lewd/e926.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     return getBlackListChannel(evt.message.channel_id).then(value => {
@@ -105,7 +109,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://e926.net/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://e926.net/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/furrybooru.js
+++ b/src/commands/lewd/furrybooru.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -111,7 +115,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
             }
           }
 

--- a/src/commands/lewd/gelbooru.js
+++ b/src/commands/lewd/gelbooru.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -111,7 +115,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
             }
           }
 

--- a/src/commands/lewd/konachan.js
+++ b/src/commands/lewd/konachan.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -109,7 +113,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://konachan.com/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://konachan.com/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/rule34.js
+++ b/src/commands/lewd/rule34.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -111,7 +115,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
             }
           }
 

--- a/src/commands/lewd/yandere.js
+++ b/src/commands/lewd/yandere.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -108,7 +112,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://yande.re/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://yande.re/post/show/${id})`;
             }
           }
 


### PR DESCRIPTION
Merge all the changes made on github web at once. 

These changes will (hopefully) add one of the tags found on the image and the blacklist to the message body of the result. This is so users have a spoiler alert for what they're about to click, since some people may be fine with certain blacklisted tags but not with others. This will allow users to better decide for themselves if they want to click the link or not, and will hopefully provide fewer lifelong mental scars.

A better system would get all matching tags between the result and blacklist and print the list, but I am a novice at Javascript so this should do for now.